### PR TITLE
Add support for CONSTANT_CASE formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
   -V, --version                    hint: you have v2.1.0
   -h, --help                       display help for command
 -------------------------
-Supported case conventions: ["pascal", "camel", "snake"].
+Supported case conventions: ["pascal", "camel", "snake", "constant"].
 Additionally, append ',plural' after any case-convention selection to mark case convention as pluralized.
 > For instance:
   --map-table-case=snake,plural

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-case-format",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Give your introspected schema.prisma sane casing conventions",
   "main": "./dist/cli.js",
   "repository": {

--- a/src/convention-store.ts
+++ b/src/convention-store.ts
@@ -1,4 +1,4 @@
-import { camelCase, pascalCase, snakeCase } from 'change-case';
+import { camelCase, pascalCase, snakeCase, constantCase } from 'change-case';
 import { CaseChange, asPluralized, asSingularized } from './caseConventions';
 import { existsSync, readFileSync } from 'fs';
 import * as jsyaml from 'js-yaml';
@@ -16,6 +16,9 @@ export function tryGetTableCaseConvention(raw_type: string): [CaseChange?, Error
     break;
     case 'snake':
     kase = snakeCase;
+    break;
+    case 'constant':
+    kase = constantCase;
     break;
     case 'false':
     case 'true':
@@ -38,7 +41,7 @@ export function tryGetTableCaseConvention(raw_type: string): [CaseChange?, Error
 }
 
 export const SUPPORTED_CASE_CONVENTIONS_MESSAGE = `-------------------------
-Supported case conventions: ["pascal", "camel", "snake"].
+Supported case conventions: ["pascal", "camel", "snake", "constant"].
 Additionally, append ',plural' after any case-convention selection to mark case convention as pluralized.
 For instance:
   --map-table-case=snake,plural
@@ -283,6 +286,9 @@ export class ConventionStore {
     if (this.children?.hasOwnProperty(camelCase(next))) {
       return this.children[camelCase(next)]._recurse(k, rest);        
     }
+    if (this.children?.hasOwnProperty(constantCase(next))) {
+      return this.children[constantCase(next)]._recurse(k, rest);        
+    }
 
     const haystack = this.children ?? {};
     for (const key in haystack) {
@@ -298,6 +304,9 @@ export class ConventionStore {
       }
       if (regex.test(camelCase(next))) {
         return this.children![camelCase(next)]._recurse(k, rest);
+      }
+      if (regex.test(constantCase(next))) {
+        return this.children![constantCase(next)]._recurse(k, rest);
       }
     }
     return undefined;

--- a/test/__snapshots__/convention-transformer.test.ts.snap
+++ b/test/__snapshots__/convention-transformer.test.ts.snap
@@ -5,8 +5,9 @@ exports[`disable2 1`] = `
   id                String   @id @default(cuid())
   passwordsSingular String[] @map("passwords_singular")
   requestsSingulars String[] @map("requests_singular")
-  columnsSingular   String[]
+  columnsSingular   String[] @map("columns_singular")
   pluralsPlurals    String[] @map("pluralsPlural")
+  plurals           String[] @map("plural")
 }
 "
 `;
@@ -230,6 +231,104 @@ model Business {
   taxId              String?              @db.VarChar(64)
   defaultTaxRate     Decimal?             @db.Decimal(8, 6)
   isActive           Boolean              @default(true)
+  batchOperation     BatchOperation[]
+  currency           Currency             @relation(fields: [currencyCode], references: [code], onUpdate: Restrict, map: "BusinessCurrency")
+  language           Language             @relation(fields: [languageCode], references: [code], onUpdate: Restrict, map: "BusinessLanguage")
+  ingredientCategory IngredientCategory[]
+  itemCategory       ItemCategory[]
+  optionCategory     OptionCategory[]
+  profile            Profile[]
+  recipe             Recipe[]
+  tab                Tab[]
+  targetGroup        TargetGroup[]
+
+  @@schema("public")
+}
+"
+`;
+
+exports[`it can enforce a specified case convention on all fields of all tables (constantCase): constantCase 1`] = `
+"datasource db {
+  provider = "sqlite"
+  url      = "file:database.db"
+}
+
+// generator
+generator client {
+  provider = "prisma-client-js"
+}
+
+model DemoIt {
+  id        Int    @id @map("ID")
+  dataField String @map("DATA_FIELD")
+}
+"
+`;
+
+exports[`it can enforce a specified case convention on all fields of all tables (constantCase): constantCase 2`] = `
+"datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Projects {
+  id         Int          @id @default(autoincrement()) @map("ID")
+  name       String?      @map("NAME") @db.VarChar
+  jiraIssues JiraIssues[]
+
+  @@map("projects")
+}
+
+model JiraIssues {
+  id                Int       @id @default(autoincrement()) @map("ID")
+  jiraIntegrationId Int?      @map("JIRA_INTEGRATION_ID")
+  projectId         Int       @map("PROJECT_ID")
+  projects          Projects? @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "jira_issues_projects_fkey")
+
+  @@map("jira_issues")
+}
+
+model FieldKey {
+  key    String @map("KEY")
+  type   String @map("TYPE") // str, num, bool
+  formId String @map("FORM_ID") @db.Uuid
+  form   Form   @relation(references: [id], fields: [formId], onDelete: Cascade)
+
+  @@id([key, formId])
+  @@map("field_key")
+}
+"
+`;
+
+exports[`it can enforce a specified case convention on all fields of all tables (constantCase): constantCase 3`] = `
+"datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Business {
+  id                 String               @id(map: "BusinessId") @default(dbgenerated("gen_random_uuid()")) @map("ID") @db.Uuid
+  languageCode       String               @map("LANGUAGE_CODE") @db.Char(2)
+  currencyCode       String               @map("CURRENCY_CODE") @db.Char(3)
+  createdAt          DateTime             @default(now()) @map("CREATED_AT") @db.Timestamptz(0)
+  name               String               @map("NAME") @db.VarChar(64)
+  language           String[]             @default([]) @map("LANGUAGE") @db.Char(2)
+  phone              String               @map("PHONE") @db.VarChar(15)
+  address            String?              @map("ADDRESS") @db.VarChar(250)
+  billingName        String?              @map("BILLING_NAME") @db.VarChar(64)
+  billingAddress     String?              @map("BILLING_ADDRESS") @db.VarChar(250)
+  taxOffice          String?              @map("TAX_OFFICE") @db.VarChar(64)
+  taxId              String?              @map("TAX_ID") @db.VarChar(64)
+  defaultTaxRate     Decimal?             @map("DEFAULT_TAX_RATE") @db.Decimal(8, 6)
+  isActive           Boolean              @default(true) @map("IS_ACTIVE")
   batchOperation     BatchOperation[]
   currency           Currency             @relation(fields: [currencyCode], references: [code], onUpdate: Restrict, map: "BusinessCurrency")
   language           Language             @relation(fields: [languageCode], references: [code], onUpdate: Restrict, map: "BusinessLanguage")
@@ -538,6 +637,107 @@ model Business {
   targetGroup        TargetGroup[]
 
   @@map("business")
+  @@schema("public")
+}
+"
+`;
+
+exports[`it can enforce a specified case convention on all table names (constantCase): constantCase 1`] = `
+"datasource db {
+  provider = "sqlite"
+  url      = "file:database.db"
+}
+
+// generator
+generator client {
+  provider = "prisma-client-js"
+}
+
+model DemoIt {
+  id        Int    @id
+  dataField String @map("data_field")
+
+  @@map("DEMO_IT")
+}
+"
+`;
+
+exports[`it can enforce a specified case convention on all table names (constantCase): constantCase 2`] = `
+"datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Projects {
+  id         Int          @id @default(autoincrement())
+  name       String?      @db.VarChar
+  jiraIssues JiraIssues[]
+
+  @@map("PROJECTS")
+}
+
+model JiraIssues {
+  id                Int       @id @default(autoincrement())
+  jiraIntegrationId Int?      @map("jira_integration_id")
+  projectId         Int       @map("project_id")
+  projects          Projects? @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "jira_issues_projects_fkey")
+
+  @@map("JIRA_ISSUES")
+}
+
+model FieldKey {
+  key    String
+  type   String // str, num, bool
+  formId String @map("form_id") @db.Uuid
+  form   Form   @relation(references: [id], fields: [formId], onDelete: Cascade)
+
+  @@id([key, formId])
+  @@map("FIELD_KEY")
+}
+"
+`;
+
+exports[`it can enforce a specified case convention on all table names (constantCase): constantCase 3`] = `
+"datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Business {
+  id                 String               @id(map: "BusinessId") @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  languageCode       String               @db.Char(2)
+  currencyCode       String               @db.Char(3)
+  createdAt          DateTime             @default(now()) @db.Timestamptz(0)
+  name               String               @db.VarChar(64)
+  language           String[]             @default([]) @db.Char(2)
+  phone              String               @db.VarChar(15)
+  address            String?              @db.VarChar(250)
+  billingName        String?              @db.VarChar(64)
+  billingAddress     String?              @db.VarChar(250)
+  taxOffice          String?              @db.VarChar(64)
+  taxId              String?              @db.VarChar(64)
+  defaultTaxRate     Decimal?             @db.Decimal(8, 6)
+  isActive           Boolean              @default(true)
+  batchOperation     BatchOperation[]
+  currency           Currency             @relation(fields: [currencyCode], references: [code], onUpdate: Restrict, map: "BusinessCurrency")
+  language           Language             @relation(fields: [languageCode], references: [code], onUpdate: Restrict, map: "BusinessLanguage")
+  ingredientCategory IngredientCategory[]
+  itemCategory       ItemCategory[]
+  optionCategory     OptionCategory[]
+  profile            Profile[]
+  recipe             Recipe[]
+  tab                Tab[]
+  targetGroup        TargetGroup[]
+
+  @@map("BUSINESS")
   @@schema("public")
 }
 "

--- a/test/convention-transformer.test.ts
+++ b/test/convention-transformer.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 
 import { join } from 'path';
 
-import { camelCase, pascalCase, snakeCase } from 'change-case';
+import { camelCase, pascalCase, snakeCase, constantCase } from 'change-case';
 import { CaseChange, ConventionTransformer } from '../src/convention-transformer';
 import { formatSchema } from '@prisma/internals';
 
@@ -109,7 +109,7 @@ test('it can account for comments on model lines', () => {
 });
 
 const supported_case_conventions: { caseConvention: CaseChange }[] = [
-  { caseConvention: snakeCase }, { caseConvention: camelCase }, { caseConvention: pascalCase }];
+  { caseConvention: snakeCase }, { caseConvention: camelCase }, { caseConvention: pascalCase }, { caseConvention: constantCase }];
 /**
  * !!Warning!! Jest snapshots are _almost_ an anti-pattern. This is because if
  * you rename the test case, and introduce a bug, the bug is now valid to Jest.
@@ -314,6 +314,20 @@ describe('must properly bring enum name to', () => {
     const [result, err] = ConventionTransformer.migrateCaseConventions(file_contents, store);
     expect(err).toBeFalsy();
     expect(result?.includes('enum post_type')).toBeTruthy();
+  });
+
+  test('CONSTANT_CASE', () => {
+    const file_contents = getFixture('enum');
+
+    const store = ConventionStore.fromConventions({
+      ...defaultConventions(),
+      tableCaseConvention: pascalCase,
+      fieldCaseConvention: camelCase,
+      enumCaseConvention: constantCase,
+    });
+    const [result, err] = ConventionTransformer.migrateCaseConventions(file_contents, store);
+    expect(err).toBeFalsy();
+    expect(result?.includes('enum POST_TYPE')).toBeTruthy();
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 {
     "compilerOptions": {
         /* Basic Options */
-        "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+        "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
         "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
         "lib": [
             "esnext"


### PR DESCRIPTION
This merge request introduces a new formatting case: CONSTANT_CASE.

The ability to format in CONSTANT_CASE is important for our project as we aim to align our Prisma enums with this style.
This format is commonly used for representing constants in many codebases and will provide better consistency when using Prisma enums in our application.
